### PR TITLE
Fix for issue #29

### DIFF
--- a/MathView/src/main/java/io/github/kexanie/library/MathView.java
+++ b/MathView/src/main/java/io/github/kexanie/library/MathView.java
@@ -21,6 +21,14 @@ public class MathView extends WebView {
 
     public MathView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        
+        if (!isInEditMode()) {  // by-pass initializations in preview mode
+            init(context, attrs);
+        }
+        
+    }
+
+    private void init(Context context, AttributeSet attrs){
         getSettings().setJavaScriptEnabled(true);
         getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         setBackgroundColor(Color.TRANSPARENT);
@@ -38,7 +46,7 @@ public class MathView extends WebView {
             mTypeArray.recycle();
         }
     }
-
+    
     // disable touch event on MathView
     @Override
     public boolean onTouchEvent(MotionEvent event) {


### PR DESCRIPTION
Skip initializations in the constructor if the MathView is in preview mode.

The reported issue is quite annoying. It occurs in recent Android Studio versions, while editing a layout xml file that contains a MathView. It complains that it can't access the getSettings() method of the WebView. Easiest fix is to skip the whole MathView-specific initializations when in preview mode.